### PR TITLE
Eduquenoy patch 1

### DIFF
--- a/assignment/assignment-tool/tool/pom.xml
+++ b/assignment/assignment-tool/tool/pom.xml
@@ -121,6 +121,21 @@
             <artifactId>poi</artifactId>
             <version>3.14</version>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -15078,7 +15078,7 @@ public class AssignmentAction extends PagedResourceActionII
 	/**
 	 * scale the point value by "factor" if there is a valid point grade
 	 */
-	private String scalePointGrade(SessionState state, String point, int factor)
+	protected String scalePointGrade(SessionState state, String point, int factor)
 	{
 		String decSeparator = FormattedText.getDecimalSeparator();
 		int dec = (int)Math.log10(factor);

--- a/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
+++ b/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
@@ -18,18 +18,11 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.event.api.SessionState;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
-import org.sakaiproject.tool.api.Tool;
-import org.sakaiproject.tool.cover.ToolManager;
 import org.sakaiproject.util.FormattedText;
 
-import lombok.extern.slf4j.Slf4j;
-
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -39,8 +32,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("deprecation")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ComponentManager.class})
-@Slf4j
-public class AssignmentActionTestTools { 
+public class AssignmentActionTestTools {
 
     private AssignmentAction assignmentAction;
     @Mock
@@ -69,7 +61,7 @@ public class AssignmentActionTestTools {
         Mockito.when(ComponentManager.get(AssignmentService.class)).thenReturn(assignmentService);
 
     }
-	
+
     //This probably should also be moved from AssignmentAction to a util or something
     public Integer getScaleFactor(Integer decimals) {		
         return (int)Math.pow(10.0, decimals);
@@ -77,56 +69,31 @@ public class AssignmentActionTestTools {
 
     @Test
     public void testScalePointGrade() {
-        SessionState state = mock(SessionState.class);
+        SessionState state = new SessionStateFake();
         //Simple state?
-        final Map <String,Object> stateAttribute = new HashMap<String,Object> ();
-        // mock for method setAttributepersist
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                Object[] arguments = invocation.getArguments();
-                if (arguments != null && arguments.length > 1 && arguments[0] != null) {
-                    stateAttribute.put((String)arguments[0], arguments[1]);
-                }
-                return null;
-            }
-        }).when(state).setAttribute(any(String.class),any(Object.class));
-
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Object[] arguments = invocation.getArguments();
-                if (arguments != null && arguments.length > 0 && arguments[0] != null) {
-                	if (arguments[0] instanceof String) {
-                		return stateAttribute.get((String)arguments[0]);
-                	}
-                }
-                return null;
-            }
-        }).when(state).getAttribute(any(String.class));
 
         Integer decimals=2;
         when(ServerConfigurationService.getInt("assignment.grading.decimals", AssignmentConstants.DEFAULT_DECIMAL_POINT)).thenReturn(decimals);
         String scaledGrade = assignmentAction.scalePointGrade(state, ".7",getScaleFactor(decimals));
         assertEquals(scaledGrade,"70");
         //Verify the state message is null
-        assertEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
-        stateAttribute.clear();
+        assertEquals(state.getAttribute(AssignmentAction.STATE_MESSAGE), null);
+        state.clear();
         
         /* This case is broken at the moment but it does return invalid in the state
          */
         scaledGrade = assignmentAction.scalePointGrade(state, "1.23456789",getScaleFactor(decimals));
         assertEquals(scaledGrade,"1.23456789");
         //Verify the state message isn't null (indicating an error)
-        assertNotEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
-        stateAttribute.clear();
+        assertNotEquals(state.getAttribute(AssignmentAction.STATE_MESSAGE), null);
+        state.clear();
 
         decimals=4;
         when(ServerConfigurationService.getInt("assignment.grading.decimals", AssignmentConstants.DEFAULT_DECIMAL_POINT)).thenReturn(decimals);
         scaledGrade = assignmentAction.scalePointGrade(state, ".7",getScaleFactor(decimals));
         assertEquals(scaledGrade,"7000");
         //Verify the state message is null
-        assertEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
-        stateAttribute.clear();
+        assertEquals(state.getAttribute(AssignmentAction.STATE_MESSAGE), null);
+        state.clear();
     }
 }

--- a/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
+++ b/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
@@ -46,7 +46,7 @@ public class AssignmentActionTestTools {
     @Mock
     private AssignmentService assignmentService;
 
-	@Before
+    @Before
     public void setUp() {
         BasicConfigurator.configure();
         PowerMockito.mockStatic(ComponentManager.class);
@@ -63,17 +63,17 @@ public class AssignmentActionTestTools {
         when(ComponentManager.get(SessionManager.class).getCurrentSession()).thenReturn(mock(Session.class));
         when(FormattedText.getDecimalSeparator()).thenReturn(".");
         
-		when(FormattedText.getNumberFormat()).thenReturn(NumberFormat.getInstance(Locale.ENGLISH));
+        when(FormattedText.getNumberFormat()).thenReturn(NumberFormat.getInstance(Locale.ENGLISH));
         assignmentAction = new AssignmentAction();
 
         Mockito.when(ComponentManager.get(AssignmentService.class)).thenReturn(assignmentService);
 
     }
 	
-	//This probably should also be moved from AssignmentAction to a util or something
-	public Integer getScaleFactor(Integer decimals) {		
-		return (int)Math.pow(10.0, decimals);
-	}
+    //This probably should also be moved from AssignmentAction to a util or something
+    public Integer getScaleFactor(Integer decimals) {		
+        return (int)Math.pow(10.0, decimals);
+    }
 
     @Test
     public void testScalePointGrade() {

--- a/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
+++ b/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/AssignmentActionTestTools.java
@@ -1,0 +1,132 @@
+package org.sakaiproject.assignment.tool;
+
+import org.apache.log4j.BasicConfigurator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.sakaiproject.assignment.api.AssignmentConstants;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.event.api.SessionState;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.api.Tool;
+import org.sakaiproject.tool.cover.ToolManager;
+import org.sakaiproject.util.FormattedText;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.*;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for AssignmentAction
+ */
+@SuppressWarnings("deprecation")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ComponentManager.class})
+@Slf4j
+public class AssignmentActionTestTools { 
+
+    private AssignmentAction assignmentAction;
+    @Mock
+    private AssignmentService assignmentService;
+
+	@Before
+    public void setUp() {
+        BasicConfigurator.configure();
+        PowerMockito.mockStatic(ComponentManager.class);
+        // A mock component manager.
+        when(ComponentManager.get(any(Class.class))).then(new Answer<Object>() {
+            private Map<Class, Object> mocks = new HashMap<>();
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Class classToMock = (Class) invocation.getArguments()[0];
+                return mocks.computeIfAbsent(classToMock, k -> mock(classToMock));
+            }
+        });
+        
+        when(ComponentManager.get(SessionManager.class).getCurrentSession()).thenReturn(mock(Session.class));
+        when(FormattedText.getDecimalSeparator()).thenReturn(".");
+        
+		when(FormattedText.getNumberFormat()).thenReturn(NumberFormat.getInstance(Locale.ENGLISH));
+        assignmentAction = new AssignmentAction();
+
+        Mockito.when(ComponentManager.get(AssignmentService.class)).thenReturn(assignmentService);
+
+    }
+	
+	//This probably should also be moved from AssignmentAction to a util or something
+	public Integer getScaleFactor(Integer decimals) {		
+		return (int)Math.pow(10.0, decimals);
+	}
+
+    @Test
+    public void testScalePointGrade() {
+        SessionState state = mock(SessionState.class);
+        //Simple state?
+        final Map <String,Object> stateAttribute = new HashMap<String,Object> ();
+        // mock for method setAttributepersist
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                if (arguments != null && arguments.length > 1 && arguments[0] != null) {
+                    stateAttribute.put((String)arguments[0], arguments[1]);
+                }
+                return null;
+            }
+        }).when(state).setAttribute(any(String.class),any(Object.class));
+
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                if (arguments != null && arguments.length > 0 && arguments[0] != null) {
+                	if (arguments[0] instanceof String) {
+                		return stateAttribute.get((String)arguments[0]);
+                	}
+                }
+                return null;
+            }
+        }).when(state).getAttribute(any(String.class));
+
+        Integer decimals=2;
+        when(ServerConfigurationService.getInt("assignment.grading.decimals", AssignmentConstants.DEFAULT_DECIMAL_POINT)).thenReturn(decimals);
+        String scaledGrade = assignmentAction.scalePointGrade(state, ".7",getScaleFactor(decimals));
+        assertEquals(scaledGrade,"70");
+        //Verify the state message is null
+        assertEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
+        stateAttribute.clear();
+        
+        /* This case is broken at the moment but it does return invalid in the state
+         */
+        scaledGrade = assignmentAction.scalePointGrade(state, "1.23456789",getScaleFactor(decimals));
+        assertEquals(scaledGrade,"1.23456789");
+        //Verify the state message isn't null (indicating an error)
+        assertNotEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
+        stateAttribute.clear();
+
+        decimals=4;
+        when(ServerConfigurationService.getInt("assignment.grading.decimals", AssignmentConstants.DEFAULT_DECIMAL_POINT)).thenReturn(decimals);
+        scaledGrade = assignmentAction.scalePointGrade(state, ".7",getScaleFactor(decimals));
+        assertEquals(scaledGrade,"7000");
+        //Verify the state message is null
+        assertEquals(stateAttribute.get(AssignmentAction.STATE_MESSAGE), null);
+        stateAttribute.clear();
+    }
+}

--- a/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/SessionStateFake.java
+++ b/assignment/assignment-tool/tool/src/test/org/sakaiproject/assignment/tool/SessionStateFake.java
@@ -1,0 +1,40 @@
+package org.sakaiproject.assignment.tool;
+
+import org.sakaiproject.event.api.SessionState;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple SessionState that just uses a map.
+ */
+public class SessionStateMap implements SessionState {
+    private Map<String, Object> map = new HashMap<>();
+
+    @Override
+    public Object getAttribute(String name) {
+        return map.get(name);
+    }
+
+    @Override
+    public Object setAttribute(String name, Object value) {
+        return map.put(name, value);
+    }
+
+    @Override
+    public Object removeAttribute(String name) {
+        return map.remove(name);
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public List<String> getAttributeNames() {
+        return new ArrayList<>(map.keySet());
+    }
+}

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.profile2.logic;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -23,9 +24,12 @@ import java.net.URLConnection;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.Setter;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 import org.sakaiproject.profile2.dao.ProfileDao;
 import org.sakaiproject.profile2.hbm.model.ProfileImageExternal;
 import org.sakaiproject.profile2.hbm.model.ProfileImageOfficial;
@@ -41,10 +45,7 @@ import org.sakaiproject.profile2.util.Messages;
 import org.sakaiproject.profile2.util.ProfileConstants;
 import org.sakaiproject.profile2.util.ProfileUtils;
 import org.sakaiproject.user.api.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import lombok.Setter;
+import org.sakaiproject.user.api.UserNotDefinedException;
 
 /**
  * Implementation of ProfileImageLogic API
@@ -54,12 +55,11 @@ import lombok.Setter;
  */
 public class ProfileImageLogicImpl implements ProfileImageLogic {
 
-	private static final Logger log = LoggerFactory.getLogger(ProfileImageLogicImpl.class);
+	private static final Logger log = Logger.getLogger(ProfileImageLogicImpl.class);
 
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getBlankProfileImage() {
 
 		ProfileImage profileImage = new ProfileImage();
@@ -71,7 +71,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getProfileImage(String userUuid, ProfilePreferences prefs, ProfilePrivacy privacy, int size) {
 		return getProfileImage(userUuid, prefs, privacy, size, null);
 	}
@@ -79,7 +78,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getOfficialProfileImage(String userUuid, String siteId) {
 		
 		ProfileImage profileImage = new ProfileImage();
@@ -105,7 +103,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getProfileImage(String userUuid, ProfilePreferences prefs, ProfilePrivacy privacy, int size, String siteId) {
 		
 		ProfileImage image = new ProfileImage();
@@ -343,7 +340,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getProfileImage(Person person, int size) {
 		return getProfileImage(person.getUuid(), person.getPreferences(), person.getPrivacy(), size, null);
 	}
@@ -351,7 +347,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public ProfileImage getProfileImage(Person person, int size, String siteId) {
 		return getProfileImage(person.getUuid(), person.getPreferences(), person.getPrivacy(), size, siteId);
 	}
@@ -360,7 +355,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean setUploadedProfileImage(String userUuid, byte[] imageBytes, String mimeType, String fileName) {
 		
 		//check auth and get currentUserUuid
@@ -444,7 +438,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean setExternalProfileImage(String userUuid, String fullSizeUrl, String thumbnailUrl, String avatar) {
 		
 		//check auth and get currentUserUuid
@@ -477,7 +470,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public boolean saveOfficialImageUrl(final String userUuid, final String url) {
 		
 		ProfileImageOfficial officialImage = new ProfileImageOfficial(userUuid, url);
@@ -493,7 +485,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean addGalleryImage(String userUuid, byte[] imageBytes, String mimeType, String fileName) {
 
 		// check auth and get currentUserUuid
@@ -538,7 +529,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public List<GalleryImage> getGalleryImages(String userUuid) {
 
 		// check auth and get currentUserUuid
@@ -553,7 +543,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public List<GalleryImage> getGalleryImagesRandomized(String userUuid) {
 		
 		List<GalleryImage> images = getGalleryImages(userUuid);
@@ -564,7 +553,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean removeGalleryImage(String userId, long imageId) {
 		if(userId == null || Long.valueOf(imageId) == null){
 	  		throw new IllegalArgumentException("Null argument in ProfileLogicImpl.removeGalleryImage()"); 
@@ -610,10 +598,11 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public String getGravatarUrl(final String userUuid) {
 		
 		String email = sakaiProxy.getUserEmail(userUuid);
+		email = email.toLowerCase(); //Ajout E.Duquenoy 
+		//log.info("Email Gravatar : "+email);
 		if(StringUtils.isBlank(email)){
 			return null;
 		}
@@ -624,7 +613,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public boolean resetProfileImage(final String userUuid) {
 		if(dao.invalidateCurrentProfileImage(userUuid)) {
 			log.info("Invalidated profile image for user: " + userUuid);
@@ -636,7 +624,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
  	 * {@inheritDoc}
  	 */
-	@Override
 	public boolean profileImageIsDefault(final String userUuid) {
 		ProfileImage image = getProfileImage(userUuid, null, null, ProfileConstants.PROFILE_IMAGE_MAIN);
 		return image.isDefault();
@@ -658,7 +645,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public String getUnavailableImageURL() {
 		return getUnavailableImageURL(ProfileConstants.UNAVAILABLE_IMAGE_FULL);
 	}
@@ -666,7 +652,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public String getUnavailableImageThumbnailURL() {
 		return getUnavailableImageURL(ProfileConstants.UNAVAILABLE_IMAGE_THUMBNAIL);
 	}
@@ -674,7 +659,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public String getProfileImageEntityUrl(String userUuid, int size) {
 	
 		StringBuilder sb = new StringBuilder();
@@ -691,7 +675,6 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public int getGalleryImagesCount(final String userUuid) {
 		return dao.getGalleryImagesCount(userUuid);
 	}

--- a/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
+++ b/profile2/impl/src/java/org/sakaiproject/profile2/logic/ProfileImageLogicImpl.java
@@ -601,11 +601,10 @@ public class ProfileImageLogicImpl implements ProfileImageLogic {
 	public String getGravatarUrl(final String userUuid) {
 		
 		String email = sakaiProxy.getUserEmail(userUuid);
-		email = email.toLowerCase(); //Ajout E.Duquenoy 
-		//log.info("Email Gravatar : "+email);
 		if(StringUtils.isBlank(email)){
 			return null;
 		}
+		email = email.toLowerCase(); //Added by E.Duquenoy (eric.duquenoy@gmail.com) june 2017
 				
 		return ProfileConstants.GRAVATAR_BASE_URL + ProfileUtils.calculateMD5(email) + "?s=200";
 	}


### PR DESCRIPTION
Convert email to **lowercase** before get Gravatar image. When an e-mail address had uppercase letters, it was not recognized by Gravatar.